### PR TITLE
use guild and default avatars

### DIFF
--- a/components/Member.tsx
+++ b/components/Member.tsx
@@ -1,6 +1,6 @@
-import { Avatar, Box, Text, FlexProps, Flex, Badge } from "@chakra-ui/react";
-import { motion } from "framer-motion";
-import { getAvatarURL, GuildMember } from "../lib/discord";
+import { Avatar, Box, Text, FlexProps, Flex, Badge } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
+import { getAvatarURL, GuildMember } from '../lib/discord';
 
 type Props = {
   member: GuildMember;
@@ -23,7 +23,7 @@ export const Member = ({ member, constraintsRef }: Props) => {
       <Box ml="3">
         <Text fontWeight="bold">{member.name}</Text>
         <Badge ml="1" colorScheme="green">
-          {member.bot ? "Bot" : "User"}
+          User
         </Badge>
       </Box>
     </MotionFlex>


### PR DESCRIPTION
- Removed the `bot` property on `GuildMember` as it was redundant because it was always being set to `false`
- Use guild avatar if available
- If neither guild nor user avatars are available, use default avatars